### PR TITLE
Refactor MCP service to HTTP/SSE and update merchant agent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ python-dotenv~=1.1.1
 protobuf~=6.32.1
 mcp~=1.14.1
 pytest~=8.4.2
+fastapi~=0.115.5
+uvicorn~=0.32.0
+httpx~=0.27.2

--- a/src/merchant_agent/agent.py
+++ b/src/merchant_agent/agent.py
@@ -1,66 +1,144 @@
-import sys
+"""Merchant agent that communicates with the MCP service over HTTP + SSE."""
 
-from mcp import StdioServerParameters
+from __future__ import annotations
 
-from google.adk.tools import MCPToolset
-from google.adk.tools.mcp_tool import StdioConnectionParams
-from google.adk.agents import Agent, LlmAgent
-from google.adk.models.lite_llm import LiteLlm
+import asyncio
+import contextlib
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
 
-from config import *
-from my_mcp import PATH_TO_MCP_SERVER
+import httpx
 
-with open("src/merchant_agent/instruction.txt", "r") as f:
-    _INSTRUCTION = f.read().strip()
+from my_mcp import MCP_API_PREFIX, build_mcp_url
+
+_INSTRUCTION = Path("src/merchant_agent/instruction.txt").read_text(encoding="utf-8").strip()
 _DESCRIPTION = "Salesperson who helps Customers to find products, calculate shipping costs and reserve stock."
 
+API_BASE_URL = build_mcp_url(MCP_API_PREFIX)
 
-def get_mcp_toolset() -> MCPToolset:
-    """Get MCP Toolset"""
-    py_cmd = sys.executable or ("python3" if os.name != "nt" else "python")
 
-    if not PATH_TO_MCP_SERVER.exists():
-        raise FileNotFoundError(f"MCP server script not found: {PATH_TO_MCP_SERVER}")
+class McpSSEClient:
+    """Minimal HTTP + SSE client for invoking MCP tools."""
 
-    # env = os.environ.copy()
-    cwd = str(PATH_TO_MCP_SERVER.parent)
+    def __init__(self, *, client_id: Optional[str] = None, api_base_url: str = API_BASE_URL) -> None:
+        self.client_id = client_id or uuid.uuid4().hex
+        self._api_base = api_base_url if api_base_url.endswith("/") else f"{api_base_url}/"
+        self._stream_url = urljoin(self._api_base, "stream")
+        self._tools_url = urljoin(self._api_base, "tools")
+        self._events: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        self._pending: List[Dict[str, Any]] = []
+        self._listener: Optional[asyncio.Task[None]] = None
 
-    return MCPToolset(
-        connection_params=StdioConnectionParams(
-            server_params=StdioServerParameters(
-                command=py_cmd,
-                args=[str(PATH_TO_MCP_SERVER)],
-                # env=env,
-                cwd=cwd,
-                # startup_timeout_seconds=15,
-                # healthcheck_command=None,  # hoặc ["python","-V"] nếu SDK hỗ trợ
+    async def connect(self) -> None:
+        if self._listener and not self._listener.done():
+            return
+        self._listener = asyncio.create_task(self._listen())
+
+    async def close(self) -> None:
+        if self._listener is None:
+            return
+        self._listener.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._listener
+        self._listener = None
+
+    async def list_tools(self) -> List[Dict[str, Any]]:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(self._tools_url)
+            response.raise_for_status()
+            payload = response.json()
+        return payload.get("tools", [])
+
+    async def invoke_tool(self, tool_name: str, arguments: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        await self.connect()
+
+        invocation_url = urljoin(self._tools_url + "/", f"{tool_name}/invoke")
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                invocation_url,
+                json={"client_id": self.client_id, "arguments": arguments or {}},
             )
-        )
-    )
+            response.raise_for_status()
+            meta = response.json()
+
+        event_id = meta.get("event_id")
+        if not event_id:
+            raise RuntimeError("MCP server did not return an event_id")
+
+        return await self._wait_for_event(event_id)
+
+    async def call_tool(self, tool_name: str, **arguments: Any) -> Dict[str, Any]:
+        return await self.invoke_tool(tool_name, arguments)
+
+    async def _listen(self) -> None:
+        params = {"client_id": self.client_id}
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream("GET", self._stream_url, params=params) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line or line.startswith(":"):
+                        continue
+                    if line.startswith("data:"):
+                        data = line.removeprefix("data:").strip()
+                        if not data:
+                            continue
+                        try:
+                            payload = json.loads(data)
+                        except json.JSONDecodeError:
+                            continue
+                        await self._events.put(payload)
+
+    async def _wait_for_event(self, event_id: str) -> Dict[str, Any]:
+        cached = self._pop_pending(event_id)
+        if cached is not None:
+            return cached
+
+        while True:
+            payload = await self._events.get()
+            if payload.get("event_id") == event_id:
+                return payload
+            self._pending.append(payload)
+
+    def _pop_pending(self, event_id: str) -> Optional[Dict[str, Any]]:
+        for idx, payload in enumerate(self._pending):
+            if payload.get("event_id") == event_id:
+                return self._pending.pop(idx)
+        return None
 
 
-def gemini_merchant_agent() -> Agent:
-    return Agent(
-        name="merchant_agent",
-        model="gemini-2.0-flash",
-        description=_DESCRIPTION,
-        instruction=_INSTRUCTION,
-        tools=[get_mcp_toolset()],
-    )
+class MerchantAgent:
+    """Simple agent facade that proxies tool calls to the MCP service."""
+
+    def __init__(self, client: Optional[McpSSEClient] = None) -> None:
+        self.name = "merchant_agent"
+        self.description = _DESCRIPTION
+        self.instruction = _INSTRUCTION
+        self.client = client or McpSSEClient(api_base_url=API_BASE_URL)
+
+    async def list_tools(self) -> List[Dict[str, Any]]:
+        return await self.client.list_tools()
+
+    async def call_tool(self, tool_name: str, **arguments: Any) -> Dict[str, Any]:
+        event = await self.client.call_tool(tool_name, **arguments)
+        if event.get("status") != "success":
+            raise RuntimeError(event.get("error", "Unknown MCP error"))
+        return event
+
+    async def call_tool_and_parse(self, tool_name: str, **arguments: Any) -> Any:
+        event = await self.call_tool(tool_name, **arguments)
+        result = event.get("result")
+        if isinstance(result, str):
+            try:
+                return json.loads(result)
+            except json.JSONDecodeError:
+                return result
+        return result
+
+    def call_tool_sync(self, tool_name: str, **arguments: Any) -> Any:
+        return asyncio.run(self.call_tool_and_parse(tool_name, **arguments))
 
 
-def llm_merchant_agent() -> LlmAgent:
-    return LlmAgent(
-        name="merchant_agent",
-        model=LiteLlm(
-            model=MODEL_NAME,
-            api_base=OPENAI_API_KEY,
-            api_key=OPENAI_API_BASE,
-        ),
-        description=_DESCRIPTION,
-        instruction=_INSTRUCTION,
-        tools=[get_mcp_toolset()],
-    )
-
-
-root_agent = gemini_merchant_agent()
+root_agent = MerchantAgent()

--- a/src/my_mcp/__init__.py
+++ b/src/my_mcp/__init__.py
@@ -1,3 +1,19 @@
-from pathlib import Path
+"""Utilities for interacting with the MCP service."""
 
-PATH_TO_MCP_SERVER = Path(__file__).parent.joinpath("server.py").resolve()
+from __future__ import annotations
+
+from urllib.parse import urljoin
+
+from config import MCP_SERVER_HOST, MCP_SERVER_PORT
+
+MCP_BASE_URL = f"http://{MCP_SERVER_HOST}:{MCP_SERVER_PORT}/"
+MCP_API_PREFIX = "mcp/"
+
+
+def build_mcp_url(path: str) -> str:
+    """Return an absolute URL pointing to the MCP service."""
+
+    return urljoin(MCP_BASE_URL, path)
+
+
+__all__ = ["MCP_BASE_URL", "MCP_API_PREFIX", "build_mcp_url"]

--- a/src/my_mcp/server.py
+++ b/src/my_mcp/server.py
@@ -1,115 +1,30 @@
-import json
-import asyncio
-from typing import Any
+"""FastAPI application exposing MCP tools over HTTP and SSE."""
 
-from my_mcp.tools import *
+from __future__ import annotations
 
-from mcp import types as mcp_types
-from mcp.server.stdio import stdio_server
-from mcp.server.models import InitializationOptions
-from mcp.server.lowlevel import Server, NotificationOptions
+from fastapi import FastAPI
 
-from google.adk.tools import FunctionTool
-from google.adk.tools.mcp_tool import adk_to_mcp_tool_type
+from my_mcp.urls import router
 
 
-print("Initializing ADK tool...")
-find_product_tool = FunctionTool(find_product)
-calc_shipping_tool = FunctionTool(calc_shipping)
-reserve_stock_tool = FunctionTool(reserve_stock)
-ADK_TOOLS = {
-    find_product_tool.name: find_product_tool,
-    calc_shipping_tool.name: calc_shipping_tool,
-    reserve_stock_tool.name: reserve_stock_tool,
-}
-for adk_tool in ADK_TOOLS.values():
-    print(f"ADK tool '{adk_tool.name}' initialized and ready to be exposed via MCP.")
+def create_app() -> FastAPI:
+    """Instantiate the FastAPI application."""
 
-my_mcp_server = Server("shop_mcp")
+    app = FastAPI(title="MCP Tool Server", version="0.1.0")
+    app.include_router(router)
+    return app
 
 
-@my_mcp_server.list_tools()
-async def list_mcp_tools() -> list[mcp_types.Tool]:
-    """Expose ADK tools to MCP as mcp_types.Tool list."""
-    print("MCP Server: Received list_tools request.")
-    exposed: list[mcp_types.Tool] = []
-
-    for _, adk_tool in ADK_TOOLS.items():
-        try:
-            mcp_tool = adk_to_mcp_tool_type(adk_tool)
-            print(f"MCP Server: Advertising tool: {mcp_tool.name}")
-            exposed.append(mcp_tool)
-        except Exception as e:
-            import traceback; traceback.print_exc()
-            print(f"[WARN] Failed to convert ADK tool '{getattr(adk_tool,'name',repr(adk_tool))}': {e}")
-
-    return exposed
+app = create_app()
 
 
-@my_mcp_server.call_tool()
-async def call_mcp_tool(name: str, arguments: dict | None) -> list[mcp_types.Content]:
-    """Execute an exposed ADK tool by name and return MCP Content parts."""
-    print(f"MCP Server: Received call_tool request for '{name}' with args: {arguments}")
+if __name__ == "__main__":  # pragma: no cover
+    from config import MCP_SERVER_HOST, MCP_SERVER_PORT
+    import uvicorn
 
-    arguments = arguments or {}
-
-    adk_tool = ADK_TOOLS.get(name)
-    if not adk_tool:
-        err = {"error": f"Tool '{name}' not implemented by this server."}
-        print(f"MCP Server: {err['error']}")
-        return [mcp_types.TextContent(type="text", text=json.dumps(err))]
-
-    try:
-        if hasattr(adk_tool, "run_async"):
-            result: Any = await adk_tool.run_async(args=arguments, tool_context=None)
-        else:
-            result: Any = adk_tool.run(args=arguments, tool_context=None)
-    except TypeError:
-        try:
-            if hasattr(adk_tool, "run_async"):
-                result: Any = await adk_tool.run_async(**arguments)
-            else:
-                result: Any = adk_tool.run(**arguments)
-        except Exception as e:
-            error_text = json.dumps({"error": f"Failed to execute tool '{name}': {str(e)}"})
-            print(f"MCP Server: {error_text}")
-            return [mcp_types.TextContent(type="text", text=error_text)]
-    except Exception as e:
-        error_text = json.dumps({"error": f"Failed to execute tool '{name}': {str(e)}"})
-        print(f"MCP Server: {error_text}")
-        return [mcp_types.TextContent(type="text", text=error_text)]
-
-    print(f"MCP Server: Tool '{name}' executed successfully.")
-    return [mcp_types.TextContent(type="text", text=result)]
-
-
-async def run_mcp_stdio_server():
-    """Runs the MCP server, listening for connections over standard input/output."""
-    # Use the stdio_server context manager from the mcp.server.stdio library
-    async with stdio_server() as (read_stream, write_stream):
-        print("MCP Stdio Server: Starting handshake with client...")
-        await my_mcp_server.run(
-            read_stream,
-            write_stream,
-            InitializationOptions(
-                server_name=my_mcp_server.name,
-                server_version="0.1.0",
-                capabilities=my_mcp_server.get_capabilities(
-                    notification_options=NotificationOptions(),
-                    experimental_capabilities={},
-                ),
-            ),
-        )
-        print("MCP Stdio Server: Run loop finished or client disconnected.")
-
-
-if __name__ == "__main__":
-    print("Launching MCP Server to expose ADK tools via stdio...")
-    try:
-        asyncio.run(run_mcp_stdio_server())
-    except KeyboardInterrupt:
-        print("\nMCP Server (stdio) stopped by user.")
-    except Exception as e:
-        print(f"MCP Server (stdio) encountered an error: {e}")
-    finally:
-        print("MCP Server (stdio) process exiting.")
+    uvicorn.run(
+        "my_mcp.server:app",
+        host=MCP_SERVER_HOST,
+        port=MCP_SERVER_PORT,
+        reload=False,
+    )

--- a/src/my_mcp/urls.py
+++ b/src/my_mcp/urls.py
@@ -1,0 +1,202 @@
+"""URL route definitions for the MCP FastAPI service."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from my_mcp import tools as mcp_tools
+
+
+@dataclass
+class ToolDefinition:
+    """Holds metadata and callable reference for a single tool."""
+
+    name: str
+    description: str
+    parameters: List[Dict[str, Any]]
+    func: Callable[..., Awaitable[Any] | Any]
+
+
+def _build_tool_definition(func: Callable[..., Any]) -> ToolDefinition:
+    """Create a ToolDefinition from a callable."""
+
+    signature = inspect.signature(func)
+    parameters: List[Dict[str, Any]] = []
+
+    for name, param in signature.parameters.items():
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+
+        annotation: Optional[str] = None
+        if param.annotation is not inspect._empty:
+            annotation = getattr(param.annotation, "__name__", str(param.annotation))
+
+        default: Any = None
+        required = True
+        if param.default is not inspect._empty:
+            default = param.default
+            required = False
+
+        parameters.append(
+            {
+                "name": name,
+                "type": annotation,
+                "required": required,
+                "default": default,
+            }
+        )
+
+    return ToolDefinition(
+        name=func.__name__,
+        description=inspect.getdoc(func) or "",
+        parameters=parameters,
+        func=func,
+    )
+
+
+TOOL_DEFINITIONS: Dict[str, ToolDefinition] = {
+    definition.name: definition
+    for definition in (
+        _build_tool_definition(mcp_tools.find_product),
+        _build_tool_definition(mcp_tools.calc_shipping),
+        _build_tool_definition(mcp_tools.reserve_stock),
+    )
+}
+
+
+class ToolInvokeRequest(BaseModel):
+    client_id: str = Field(..., description="Unique identifier of the caller's SSE session")
+    arguments: Dict[str, Any] = Field(default_factory=dict, description="Arguments passed to the tool")
+
+
+class ToolInvokeResponse(BaseModel):
+    status: str
+    event_id: str
+
+
+class ToolListResponse(BaseModel):
+    tools: List[Dict[str, Any]]
+
+
+class EventBroker:
+    """Manages SSE queues per connected client."""
+
+    def __init__(self) -> None:
+        self._clients: Dict[str, asyncio.Queue[Dict[str, Any]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def connect(self, client_id: str) -> asyncio.Queue[Dict[str, Any]]:
+        async with self._lock:
+            queue = self._clients.get(client_id)
+            if queue is None:
+                queue = asyncio.Queue()
+                self._clients[client_id] = queue
+            return queue
+
+    async def disconnect(self, client_id: str) -> None:
+        async with self._lock:
+            self._clients.pop(client_id, None)
+
+    async def publish(self, client_id: str, message: Dict[str, Any]) -> None:
+        queue = await self.connect(client_id)
+        await queue.put(message)
+
+
+broker = EventBroker()
+router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+
+async def _execute_tool(definition: ToolDefinition, arguments: Dict[str, Any]) -> Any:
+    func = definition.func
+    if inspect.iscoroutinefunction(func):
+        return await func(**arguments)
+    return await asyncio.to_thread(func, **arguments)
+
+
+async def _stream_events(client_id: str) -> AsyncGenerator[str, None]:
+    queue = await broker.connect(client_id)
+    try:
+        while True:
+            try:
+                payload = await asyncio.wait_for(queue.get(), timeout=15.0)
+                yield f"data: {json.dumps(payload)}\n\n"
+            except asyncio.TimeoutError:
+                # Keep the connection alive while no events are available.
+                yield ": keep-alive\n\n"
+    except asyncio.CancelledError:
+        raise
+    finally:
+        await broker.disconnect(client_id)
+
+
+@router.get("/tools", response_model=ToolListResponse)
+async def list_tools() -> ToolListResponse:
+    """Expose metadata about the available tools."""
+
+    return ToolListResponse(
+        tools=[
+            {
+                "name": definition.name,
+                "description": definition.description,
+                "parameters": definition.parameters,
+            }
+            for definition in TOOL_DEFINITIONS.values()
+        ]
+    )
+
+
+@router.get("/stream")
+async def stream(client_id: str):
+    """Establish an SSE stream for the given client identifier."""
+
+    if not client_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="client_id is required")
+
+    generator = _stream_events(client_id)
+    return StreamingResponse(generator, media_type="text/event-stream")
+
+
+@router.post(
+    "/tools/{tool_name}/invoke",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=ToolInvokeResponse,
+)
+async def invoke_tool(tool_name: str, request: ToolInvokeRequest) -> ToolInvokeResponse:
+    """Schedule tool execution and stream the result back to the caller."""
+
+    definition = TOOL_DEFINITIONS.get(tool_name)
+    if definition is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Tool '{tool_name}' not found")
+
+    event_id = str(uuid.uuid4())
+
+    async def _run_tool() -> None:
+        try:
+            result = await _execute_tool(definition, request.arguments)
+            payload = {
+                "event_id": event_id,
+                "tool": tool_name,
+                "status": "success",
+                "result": result,
+            }
+        except Exception as exc:  # noqa: BLE001 - surface tool errors to caller
+            payload = {
+                "event_id": event_id,
+                "tool": tool_name,
+                "status": "error",
+                "error": str(exc),
+            }
+        await broker.publish(request.client_id, payload)
+
+    asyncio.create_task(_run_tool())
+
+    return ToolInvokeResponse(status="scheduled", event_id=event_id)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Pytest plugin to execute asyncio marked tests without external dependencies."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+
+@pytest.hookimpl
+def pytest_configure(config: pytest.Config) -> None:  # pragma: no cover - pytest hook
+    config.addinivalue_line(
+        "markers",
+        "asyncio: mark test to run inside an event loop",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool:  # pragma: no cover - pytest hook
+    if "asyncio" not in pyfuncitem.keywords:
+        return False
+
+    test_function = pyfuncitem.obj
+    if not inspect.iscoroutinefunction(test_function):
+        return False
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(test_function(**pyfuncitem.funcargs))
+    finally:
+        loop.close()
+    return True


### PR DESCRIPTION
## Summary
- replace the old stdio MCP server with a FastAPI app that exposes tool metadata, invocation, and SSE streaming via `my_mcp/urls.py`
- update the merchant agent to call the MCP service over HTTP and listen for responses through an SSE client
- add a lightweight pytest plugin so async tests run without external dependencies and document new runtime dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfcaece93c832cb13c28eeba3e2be9