### PR TITLE
Integrate payment task helpers into salesperson agent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ litellm~=1.77.1
 pydantic~=2.11.9
 a2a-sdk~=0.3.6
 httpx~=0.28.1
+email-validator~=2.2.0

--- a/src/my_agent/salesperson_agent/agent.py
+++ b/src/my_agent/salesperson_agent/agent.py
@@ -1,5 +1,9 @@
+import os
+
 from google.adk.agents import Agent, LlmAgent
 from google.adk.models.lite_llm import LiteLlm
+
+from config import *
 
 from .skills import *
 from my_mcp.mcp_toolset import get_mcp_toolset
@@ -23,8 +27,9 @@ def gemini_salesperson_agent() -> Agent:
         sub_agents=[get_payment_remote()],
         tools=[
             get_mcp_toolset(mcp_streamable_http_url),
-            correlation_id_tool,
-            get_return_cancel_url_for_payment_tool,
+            generate_correlation_id_tool,
+            generate_return_url_tool,
+            generate_cancel_url_tool,
         ],
     )
 
@@ -42,8 +47,9 @@ def llm_salesperson_agent() -> LlmAgent:
         sub_agents=[get_payment_remote()],
         tools=[
             get_mcp_toolset(mcp_streamable_http_url),
-            correlation_id_tool,
-            get_return_cancel_url_for_payment_tool,
+            generate_correlation_id_tool,
+            generate_return_url_tool,
+            generate_cancel_url_tool,
         ],
     )
 

--- a/src/my_agent/salesperson_agent/payment_tasks.py
+++ b/src/my_agent/salesperson_agent/payment_tasks.py
@@ -1,0 +1,97 @@
+"""Helpers for building payment-related A2A tasks for the salesperson agent.
+
+This module keeps the orchestration logic in one place so new developers can
+read through the step-by-step flow:
+
+1. Create a correlation ID that uniquely identifies the payment request.
+2. Generate the return and cancel URLs bound to that correlation ID.
+3. Use the shared :mod:`my_a2a` helpers to build the task payload that will be
+   sent to the remote payment agent.
+
+The high-level function :func:`build_salesperson_create_order_task` exposes an
+easy-to-use wrapper around :func:`my_a2a.build_create_order_task` while still
+following the protocol requirements from the payment team.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+from my_a2a import build_create_order_task, build_query_status_task
+from my_a2a.payment_schemas.payment_enums import PaymentChannel
+
+from .skills import (
+    generate_cancel_url,
+    generate_correlation_id,
+    generate_return_url,
+)
+
+
+def _default_correlation_id_factory(prefix: str) -> str:
+    """Delegate to :func:`generate_correlation_id` for actual ID creation."""
+
+    return generate_correlation_id(prefix=prefix)
+
+
+def _default_url_factory(correlation_id: str) -> Tuple[str, str]:
+    """Return the pair of return/cancel URLs used by the payment gateway."""
+
+    return (
+        generate_return_url(correlation_id),
+        generate_cancel_url(correlation_id),
+    )
+
+
+def build_salesperson_create_order_task(
+    items: Sequence[Any],
+    customer: Any,
+    channel: PaymentChannel,
+    *,
+    note: Optional[str] = None,
+    metadata: Optional[Dict[str, str]] = None,
+) -> "Task":
+    """Create the payment order task with the required system fields injected.
+
+    Parameters
+    ----------
+    items:
+        Collection of items the customer wants to purchase. The helper accepts
+        both raw dictionaries and :class:`~my_a2a.payment_schemas.PaymentItem`
+        instances; the underlying :func:`build_create_order_task` takes care of
+        normalising them.
+    customer:
+        Information about the customer. Either a dictionary or a
+        :class:`~my_a2a.payment_schemas.CustomerInfo` instance.
+    channel:
+        Which payment channel to use (``REDIRECT`` or ``QR``).
+    note, metadata:
+        Optional fields that are passed straight through to the payment agent.
+
+    Returns
+    -------
+    Task
+        A fully-prepared :class:`~a2a.types.Task` instance ready to be sent to
+        the remote payment agent.
+    """
+
+    return build_create_order_task(
+        items,
+        customer,
+        channel,
+        _default_correlation_id_factory,
+        _default_url_factory,
+        note=note,
+        metadata=metadata,
+    )
+
+
+def build_salesperson_query_status_task(correlation_id: str) -> "Task":
+    """Wrapper that exposes query-status functionality alongside create order."""
+
+    return build_query_status_task(correlation_id)
+
+
+__all__ = [
+    "build_salesperson_create_order_task",
+    "build_salesperson_query_status_task",
+]

--- a/src/my_agent/salesperson_agent/skills.py
+++ b/src/my_agent/salesperson_agent/skills.py
@@ -1,20 +1,50 @@
-import uuid
+"""Utility tools that the salesperson agent can invoke while handling payments."""
 
-from config import *
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from config import CANCEL_URL, RETURN_URL
 
 from google.adk.tools import FunctionTool
 
 
-def correlation_id(prefix: str) -> str:
-    """Generate a unique correlation ID with the given prefix for A2A interactions."""
-    return f"{prefix}-{str(uuid.uuid4())}"
+@dataclass(frozen=True)
+class PaymentUrls:
+    """Bundle the return and cancel URLs generated for a payment session."""
+
+    return_url: str
+    cancel_url: str
 
 
-def get_return_cancel_url_for_payment(correlation_id: str) -> tuple[str, str]:
-    """Generate return and cancel URLs for payment with the given correlation ID."""
-    return (f"{RETURN_URL}?cid={correlation_id}",
-            f"{CANCEL_URL}?cid={correlation_id}")
+def generate_correlation_id(prefix: str = "payment") -> str:
+    """Create a unique correlation identifier used to track payment requests."""
+
+    return f"{prefix}-{uuid.uuid4()}"
 
 
-correlation_id_tool = FunctionTool(correlation_id)
-get_return_cancel_url_for_payment_tool = FunctionTool(get_return_cancel_url_for_payment)
+def generate_return_url(correlation_id: str) -> str:
+    """Build the return URL that the payment gateway should redirect to."""
+
+    return f"{RETURN_URL}?cid={correlation_id}"
+
+
+def generate_cancel_url(correlation_id: str) -> str:
+    """Build the cancel URL that the payment gateway should redirect to."""
+
+    return f"{CANCEL_URL}?cid={correlation_id}"
+
+
+def get_payment_urls(correlation_id: str) -> PaymentUrls:
+    """Convenience helper that returns both return and cancel URLs."""
+
+    return PaymentUrls(
+        return_url=generate_return_url(correlation_id),
+        cancel_url=generate_cancel_url(correlation_id),
+    )
+
+
+generate_correlation_id_tool = FunctionTool(generate_correlation_id)
+generate_return_url_tool = FunctionTool(generate_return_url)
+generate_cancel_url_tool = FunctionTool(generate_cancel_url)

--- a/src/tests/test_salesperson_payment_tasks.py
+++ b/src/tests/test_salesperson_payment_tasks.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from my_a2a import extract_payment_request
+from my_a2a.payment_schemas.payment_enums import PaymentChannel
+
+from my_agent.salesperson_agent.payment_tasks import (
+    build_salesperson_create_order_task,
+    build_salesperson_query_status_task,
+)
+
+
+def _dummy_items() -> list[dict[str, object]]:
+    return [
+        {
+            "sku": "ABC",
+            "name": "Sample Product",
+            "quantity": 1,
+            "unit_price": 42.0,
+            "currency": "USD",
+        }
+    ]
+
+
+def _dummy_customer() -> dict[str, str]:
+    return {"name": "Bob", "email": "bob@example.com"}
+
+
+def test_build_salesperson_create_order_task_generates_system_fields() -> None:
+    with (
+        patch(
+            "my_agent.salesperson_agent.payment_tasks.generate_correlation_id",
+            return_value="CID-123",
+        ) as mock_corr,
+        patch(
+            "my_agent.salesperson_agent.payment_tasks.generate_return_url",
+            return_value="https://return.example/CID-123",
+        ) as mock_return,
+        patch(
+            "my_agent.salesperson_agent.payment_tasks.generate_cancel_url",
+            return_value="https://cancel.example/CID-123",
+        ) as mock_cancel,
+    ):
+        task = build_salesperson_create_order_task(
+            _dummy_items(),
+            _dummy_customer(),
+            PaymentChannel.REDIRECT,
+        )
+
+    mock_corr.assert_called_once_with(prefix="payment")
+    mock_return.assert_called_once_with("CID-123")
+    mock_cancel.assert_called_once_with("CID-123")
+
+    request = extract_payment_request(task)
+    assert request.correlation_id == "CID-123"
+    assert request.method.return_url == "https://return.example/CID-123"
+    assert request.method.cancel_url == "https://cancel.example/CID-123"
+
+
+def test_build_salesperson_query_status_task_passthrough() -> None:
+    task = build_salesperson_query_status_task("CID-999")
+    assert task.context_id == "CID-999"


### PR DESCRIPTION
## Summary
- expose explicit payment utility tools (correlation id and URLs) for the salesperson agent
- add a helper module that builds payment A2A tasks using the new utilities
- cover the new flow with unit tests and declare the email-validator dependency required by Pydantic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36526dd58832cac6bbd56fad3e756