### PR TITLE
Standardize tool response payloads to ResponseFormat JSON

### DIFF
--- a/src/my_mcp/payment/tools_for_payment_agent.py
+++ b/src/my_mcp/payment/tools_for_payment_agent.py
@@ -7,6 +7,7 @@ from my_a2a_common.payment_schemas.payment_enums import *
 from my_a2a_common.payment_schemas.next_action import NextAction
 from my_a2a_common.payment_schemas.payment_request import PaymentRequest
 from my_a2a_common.payment_schemas.payment_response import PaymentResponse
+from utils.response_format import ResponseFormat
 
 
 async def _stub_paygate_create(channel: PaymentChannel, total: float, return_url: Optional[str], cancel_url: Optional[str]):
@@ -18,7 +19,7 @@ async def _stub_paygate_create(channel: PaymentChannel, total: float, return_url
     return {"order_id": oid, "qr_code_url": f"{QR_URL}/{oid}.png", "expires_at": exp}
 
 
-async def create_order(payload: dict[str, Any]) -> dict[str, Any]:
+async def create_order(payload: dict[str, Any]) -> str:
     """
     Create a payment order on a payment paygate and return next_action for the customer.
     Args:
@@ -63,17 +64,18 @@ async def create_order(payload: dict[str, Any]) -> dict[str, Any]:
         expires_at=paygate_response["expires_at"],
         next_action=next_action,
     )
-    return res.model_dump()
+    return ResponseFormat(data=res.model_dump()).to_json()
 
 
-async def query_order_status(payload: dict[str, Any]) -> dict[str, Any]:
+async def query_order_status(payload: dict[str, Any]) -> str:
     """
     Query order status by correlation_id
     Args:
       payload: {"correlation_id": "..."}
     """
     cid = payload["correlation_id"]
-    return PaymentResponse(correlation_id=cid, status=PaymentStatus.FAILED).model_dump()
+    res = PaymentResponse(correlation_id=cid, status=PaymentStatus.FAILED)
+    return ResponseFormat(data=res.model_dump()).to_json()
 
 
 print("Initializing ADK tool for payment...")

--- a/src/my_mcp/salesperson/tools_for_salesperson_agent.py
+++ b/src/my_mcp/salesperson/tools_for_salesperson_agent.py
@@ -61,17 +61,20 @@ async def reserve_stock(sku: str, quantity: int) -> str:
 
 async def generate_correlation_id(prefix: str) -> str:
     """Create a unique correlation identifier used to track payment requests."""
-    return f"{prefix}-{uuid.uuid4()}"
+    correlation_id = f"{prefix}-{uuid.uuid4()}"
+    return ResponseFormat(data=correlation_id).to_json()
 
 
 async def generate_return_url(correlation_id: str) -> str:
     """Build the return URL that the payment gateway should redirect to."""
-    return f"{RETURN_URL}?cid={correlation_id}"
+    return_url = f"{RETURN_URL}?cid={correlation_id}"
+    return ResponseFormat(data=return_url).to_json()
 
 
 async def generate_cancel_url(correlation_id: str) -> str:
     """Build the cancel URL that the payment gateway should redirect to."""
-    return f"{CANCEL_URL}?cid={correlation_id}"
+    cancel_url = f"{CANCEL_URL}?cid={correlation_id}"
+    return ResponseFormat(data=cancel_url).to_json()
 
 
 print("Initializing ADK tool for salesperson...")


### PR DESCRIPTION
## Summary
- wrap the salesperson helper tools for correlation id and URL generation in the shared ResponseFormat JSON structure
- return ResponseFormat JSON payloads from the payment agent's create_order and query_order_status tools to align with other tools

## Testing
- pytest *(fails: missing dependency `email_validator` required by pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68d5326bb87c832cb79fc5f97d92035d