### PR TITLE
Add reusable A2A client layer and JSON-RPC payment endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ litellm~=1.77.1
 pydantic~=2.11.9
 a2a-sdk~=0.3.6
 httpx~=0.28.1
+email-validator~=2.1.1
 

--- a/src/my_a2a_common/__init__.py
+++ b/src/my_a2a_common/__init__.py
@@ -17,7 +17,6 @@ from a2a.types import (
 from .a2a_salesperson_payment import (
     CREATE_ORDER_SKILL,
     CREATE_ORDER_SKILL_ID,
-    PaymentAgentHandler,
     QUERY_STATUS_SKILL,
     QUERY_STATUS_SKILL_ID,
     build_create_order_message,
@@ -41,7 +40,6 @@ __all__ = [
     "TaskStatus",
     "CREATE_ORDER_SKILL",
     "CREATE_ORDER_SKILL_ID",
-    "PaymentAgentHandler",
     "QUERY_STATUS_SKILL",
     "QUERY_STATUS_SKILL_ID",
     "build_create_order_message",

--- a/src/my_agent/base_a2a_client.py
+++ b/src/my_agent/base_a2a_client.py
@@ -1,0 +1,186 @@
+"""Shared HTTP helpers for talking to remote A2A agents.
+
+The payment flow currently ships with a dedicated :class:`SalespersonA2AClient`
+but a number of other agents will eventually need to speak the same JSON-RPC
+protocol.  This module hosts a small, well-tested base class that understands
+how to serialise :class:`~a2a.types.Task` objects into ``message.send`` calls and
+how to parse the structured :mod:`utils.response_format` responses returned by
+the server.
+
+Keeping the networking code here allows individual agents to focus on their
+business logic while still benefitting from the same error handling and
+transport behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Mapping
+
+import httpx
+from a2a.types import Message, MessageSendParams, Task
+
+from utils.status import Status
+
+
+class BaseA2AClient:
+    """Lightweight client for sending JSON-RPC ``message.send`` requests."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        client: httpx.AsyncClient | None = None,
+        timeout: float = 10.0,
+        endpoint_path: str = "/",
+    ) -> None:
+        self._base_url = base_url
+        self._endpoint_path = endpoint_path
+        if client is None:
+            self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout)
+            self._owns_client = True
+        else:
+            self._client = client
+            self._owns_client = False
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client if this instance created it."""
+
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "BaseA2AClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def send_message(
+        self,
+        params: MessageSendParams,
+        *,
+        request_id: str | None = None,
+    ) -> Message:
+        """Send a pre-built ``MessageSendParams`` payload to the remote agent."""
+
+        payload = self._build_json_rpc_request(params, request_id=request_id)
+        response = await self._client.post(self._endpoint_path, json=payload)
+        response.raise_for_status()
+        try:
+            body = response.json()
+        except json.JSONDecodeError as exc:  # pragma: no cover - httpx guards well
+            raise RuntimeError("Remote A2A agent returned non-JSON response") from exc
+        message_payload = self._extract_message_from_response(body)
+        return Message.model_validate(message_payload)
+
+    async def send_task(
+        self,
+        task: Task,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        request_id: str | None = None,
+        message: Message | None = None,
+    ) -> Message:
+        """Send the last message associated with ``task`` to the remote agent."""
+
+        if message is None:
+            if not task.history:
+                raise ValueError("Task does not contain any messages to send")
+            message = task.history[-1]
+
+        metadata_payload = dict(metadata or {})
+        metadata_payload.setdefault("task", task.model_dump(mode="json"))
+
+        params = MessageSendParams(message=message, metadata=metadata_payload)
+        return await self.send_message(params, request_id=request_id)
+
+    async def send_task_payload(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        request_id: str | None = None,
+    ) -> Message:
+        """Convenience wrapper that accepts a serialised task mapping."""
+
+        task_payload = payload.get("task")
+        if task_payload is None:
+            raise ValueError("Payload is missing the 'task' entry required by A2A")
+
+        task = Task.model_validate(task_payload)
+        return await self.send_task(
+            task,
+            metadata=metadata,
+            request_id=request_id,
+        )
+
+    def _build_json_rpc_request(
+        self,
+        params: MessageSendParams,
+        *,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id or str(uuid.uuid4()),
+            "method": "message.send",
+            "params": params.model_dump(mode="json"),
+        }
+
+    @staticmethod
+    def _ensure_response_format(payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                "Remote A2A agent returned a malformed JSON-RPC result payload",
+            )
+
+        missing = [key for key in ("status", "message", "data") if key not in payload]
+        if missing:
+            raise RuntimeError(
+                "Remote A2A agent returned ResponseFormat missing keys: " + ", ".join(missing)
+            )
+
+        return payload
+
+    @classmethod
+    def _extract_success_data(cls, payload: Any) -> Any:
+        response = cls._ensure_response_format(payload)
+        status = response.get("status")
+        if status != Status.SUCCESS.value:
+            message = response.get("message", "")
+            raise RuntimeError(
+                f"Remote A2A agent returned status '{status}': {message}"
+            )
+        return response.get("data")
+
+    @classmethod
+    def _extract_message_from_response(cls, payload: Any) -> Any:
+        if not isinstance(payload, dict):
+            raise RuntimeError("Remote A2A agent returned a non-object JSON-RPC response")
+
+        if "error" in payload:
+            error_obj = payload["error"]
+            if isinstance(error_obj, dict):
+                code = error_obj.get("code")
+                message = error_obj.get("message", "")
+                detail = error_obj.get("data")
+                detail_text = f" Details: {detail}" if detail is not None else ""
+                raise RuntimeError(
+                    f"Remote A2A agent returned JSON-RPC error {code}: {message}{detail_text}"
+                )
+            raise RuntimeError("Remote A2A agent returned JSON-RPC error response")
+
+        result = payload.get("result")
+        if result is None:
+            raise RuntimeError("Remote A2A agent response does not contain 'result'")
+
+        data = cls._extract_success_data(result)
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                "Remote A2A agent ResponseFormat 'data' entry must be a mapping"
+            )
+        return data
+
+
+__all__ = ["BaseA2AClient"]

--- a/src/my_agent/payment_agent/payment_a2a/__init__.py
+++ b/src/my_agent/payment_agent/payment_a2a/__init__.py
@@ -1,0 +1,14 @@
+"""Public exports for the payment agent's A2A server."""
+
+from .a2a_app import a2a_app, build_payment_agent_card
+from .payment_agent_handler import PaymentAgentHandler, validate_payment_response
+from .payment_agent_skills import CREATE_ORDER_SKILL_ID, QUERY_STATUS_SKILL_ID
+
+__all__ = [
+    "a2a_app",
+    "build_payment_agent_card",
+    "PaymentAgentHandler",
+    "validate_payment_response",
+    "CREATE_ORDER_SKILL_ID",
+    "QUERY_STATUS_SKILL_ID",
+]

--- a/src/my_agent/payment_agent/payment_a2a/a2a_app.py
+++ b/src/my_agent/payment_agent/payment_a2a/a2a_app.py
@@ -1,39 +1,33 @@
-from a2a.types import AgentCard, AgentCapabilities
-from google.adk.a2a.utils.agent_to_a2a import to_a2a
+"""Starlette application that exposes the payment agent over JSON-RPC."""
 
-from my_a2a_common import CREATE_ORDER_SKILL, QUERY_STATUS_SKILL
-from my_a2a_common.a2a_salesperson_payment.constants import JSON_MEDIA_TYPE
+from __future__ import annotations
 
-from my_agent.payment_agent.agent import root_agent
+import asyncio
+import json
+import logging
+from typing import Any
+
+from a2a.types import AgentCapabilities, AgentCard, MessageSendParams, Task
+from pydantic import ValidationError
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
 from config import PAYMENT_AGENT_SERVER_HOST, PAYMENT_AGENT_SERVER_PORT
+from my_a2a_common.a2a_salesperson_payment.constants import JSON_MEDIA_TYPE
+from .payment_agent_skills import CREATE_ORDER_SKILL, QUERY_STATUS_SKILL
+from utils.response_format import ResponseFormat
+
+from my_agent.payment_agent.payment_a2a.payment_agent_handler import PaymentAgentHandler
+from my_agent.payment_agent.payment_mcp_client import create_order, query_order_status
+
+
+logger = logging.getLogger(__name__)
 
 
 def build_payment_agent_card(base_url: str) -> AgentCard:
-    """Describe the payment agent using the official SDK models.
-
-    Parameters
-    ----------
-    base_url:
-        The JSON-RPC endpoint where other agents can reach the payment agent.
-
-    The resulting card highlights how each field of :class:`AgentCard` is used:
-    ``name`` and ``description``
-        Human friendly metadata for discovery.
-    ``version``
-        The payment agent's own release number so clients can reason about
-        backwards compatibility.
-    ``url``
-        Entry point where :class:`~a2a.types.MessageSendParams` requests should
-        be POSTed.
-    ``default_input_modes`` / ``default_output_modes``
-        Express that the agent expects JSON payloads by default.
-    ``capabilities``
-        Flags whether the agent supports streaming, push notifications or
-        publishes state transition history. We disable the advanced features to
-        keep the tutorial simple.
-    ``skills``
-        Lists the :class:`AgentSkill` objects declared in :mod:`my_a2a_common.payment.skills`.
-    """
+    """Describe the payment agent using the official SDK models."""
 
     capabilities = AgentCapabilities(
         streaming=False,
@@ -53,22 +47,102 @@ def build_payment_agent_card(base_url: str) -> AgentCard:
     )
 
 
+def _sync_adapter(async_callable):
+    async def _run(payload: dict[str, Any]) -> dict[str, Any]:
+        return await async_callable(payload)
+
+    def _wrapper(payload: dict[str, Any]) -> dict[str, Any]:
+        return asyncio.run(_run(payload))
+
+    return _wrapper
+
+
+_PAYMENT_HANDLER = PaymentAgentHandler(
+    create_order_tool=_sync_adapter(create_order),
+    query_status_tool=_sync_adapter(query_order_status),
+)
+
 _CARD_BASE_URL = f"http://{PAYMENT_AGENT_SERVER_HOST}:{PAYMENT_AGENT_SERVER_PORT}/"
 _PAYMENT_AGENT_CARD = build_payment_agent_card(_CARD_BASE_URL)
 
 
-a2a_app = to_a2a(
-    root_agent,
-    host=PAYMENT_AGENT_SERVER_HOST,
-    port=PAYMENT_AGENT_SERVER_PORT,
-    agent_card=_PAYMENT_AGENT_CARD,
-)
+def _json_rpc_error_response(
+    request_id: str | None,
+    *,
+    code: int,
+    message: str,
+    data: Any | None = None,
+) -> JSONResponse:
+    error_payload: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error_payload["data"] = data
 
-
-if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run(
-        "my_agent.payment_agent.payment_a2a.a2a_app:a2a_app",
-        host="0.0.0.0",
-        port=PAYMENT_AGENT_SERVER_PORT,
+    status_code = 500 if code == -32603 else 400 if code == -32700 else 200
+    return JSONResponse(
+        {"jsonrpc": "2.0", "id": request_id, "error": error_payload},
+        status_code=status_code,
     )
+
+
+async def _handle_message_send(request: Request) -> Response:
+    try:
+        payload = await request.json()
+    except (json.JSONDecodeError, ValueError):
+        return _json_rpc_error_response(None, code=-32700, message="Invalid JSON payload")
+
+    request_id = payload.get("id")
+    if payload.get("jsonrpc") != "2.0":
+        return _json_rpc_error_response(request_id, code=-32600, message="Invalid JSON-RPC version")
+
+    if payload.get("method") != "message.send":
+        return _json_rpc_error_response(request_id, code=-32601, message="Unsupported method")
+
+    params_payload = payload.get("params")
+    if params_payload is None:
+        return _json_rpc_error_response(request_id, code=-32602, message="Missing params")
+
+    try:
+        params = MessageSendParams.model_validate(params_payload)
+    except ValidationError as exc:
+        return _json_rpc_error_response(request_id, code=-32602, message="Invalid params", data=exc.errors())
+
+    metadata = params.metadata or {}
+    task_payload = metadata.get("task")
+    if task_payload is None:
+        return _json_rpc_error_response(request_id, code=-32602, message="Missing task metadata")
+
+    try:
+        task = Task.model_validate(task_payload)
+    except ValidationError as exc:
+        return _json_rpc_error_response(request_id, code=-32602, message="Invalid task payload", data=exc.errors())
+
+    try:
+        message = await asyncio.to_thread(_PAYMENT_HANDLER.handle_task, task)
+    except Exception as exc:  # pragma: no cover - defensive path
+        logger.exception("Payment agent failed to handle task")
+        return _json_rpc_error_response(request_id, code=-32603, message="Internal error", data=str(exc))
+
+    response_format = ResponseFormat(data=message.model_dump(mode="json"))
+    return JSONResponse(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": response_format.to_dict(),
+        }
+    )
+
+
+async def _handle_agent_card(_: Request) -> Response:
+    return JSONResponse(_PAYMENT_AGENT_CARD.model_dump(mode="json"))
+
+
+routes = [
+    Route("/.well-known/agent.json", _handle_agent_card, methods=["GET"]),
+    Route("/", _handle_message_send, methods=["POST"]),
+]
+
+
+a2a_app = Starlette(debug=False, routes=routes)
+
+
+__all__ = ["a2a_app", "build_payment_agent_card"]

--- a/src/my_agent/salesperson_agent/salesperson_a2a/__init__.py
+++ b/src/my_agent/salesperson_agent/salesperson_a2a/__init__.py
@@ -1,0 +1,22 @@
+"""Public helpers for the salesperson ↔ payment A2A integration."""
+
+from .client import PaymentAgentResult, SalespersonA2AClient
+from .payment_tasks import (
+    prepare_create_order_payload,
+    prepare_create_order_payload_tool,
+    prepare_create_order_payload_with_client,
+    prepare_query_status_payload,
+    prepare_query_status_payload_tool,
+)
+from .remote_agent import get_remote_payment_agent
+
+__all__ = [
+    "PaymentAgentResult",
+    "SalespersonA2AClient",
+    "prepare_create_order_payload",
+    "prepare_create_order_payload_tool",
+    "prepare_create_order_payload_with_client",
+    "prepare_query_status_payload",
+    "prepare_query_status_payload_tool",
+    "get_remote_payment_agent",
+]

--- a/src/my_agent/salesperson_agent/salesperson_a2a/client.py
+++ b/src/my_agent/salesperson_agent/salesperson_a2a/client.py
@@ -1,0 +1,70 @@
+"""Convenience wrapper for the salesperson agent to call the payment agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from a2a.types import Message, Task
+
+from config import PAYMENT_AGENT_SERVER_HOST, PAYMENT_AGENT_SERVER_PORT
+from my_a2a_common import extract_payment_response
+from my_a2a_common.payment_schemas import PaymentResponse
+
+from my_agent.base_a2a_client import BaseA2AClient
+
+
+PAYMENT_AGENT_BASE_URL = f"http://{PAYMENT_AGENT_SERVER_HOST}:{PAYMENT_AGENT_SERVER_PORT}"
+
+
+@dataclass
+class PaymentAgentResult:
+    """Structured representation of the payment agent's reply."""
+
+    message: Message
+    response: PaymentResponse
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable view of the result for logging or tests."""
+
+        return {
+            "message": self.message.model_dump(mode="json"),
+            "response": self.response.model_dump(mode="json"),
+        }
+
+
+class SalespersonA2AClient(BaseA2AClient):
+    """Client used by the salesperson agent to reach the payment service."""
+
+    def __init__(self, *, base_url: str | None = None, **kwargs: Any) -> None:
+        super().__init__(
+            base_url=base_url or PAYMENT_AGENT_BASE_URL,
+            endpoint_path="/",
+            **kwargs,
+        )
+
+    @staticmethod
+    def _task_from_payload(payload: Mapping[str, Any]) -> Task:
+        task_payload = payload.get("task")
+        if task_payload is None:
+            raise ValueError("Expected payload to contain 'task' entry")
+        return Task.model_validate(task_payload)
+
+    async def create_order(self, payload: Mapping[str, Any]) -> PaymentAgentResult:
+        """Send the create-order task to the payment agent and parse the reply."""
+
+        task = self._task_from_payload(payload)
+        message = await self.send_task(task)
+        response = extract_payment_response(message)
+        return PaymentAgentResult(message=message, response=response)
+
+    async def query_status(self, payload: Mapping[str, Any]) -> PaymentAgentResult:
+        """Send the status lookup task to the payment agent and parse the reply."""
+
+        task = self._task_from_payload(payload)
+        message = await self.send_task(task)
+        response = extract_payment_response(message)
+        return PaymentAgentResult(message=message, response=response)
+
+
+__all__ = ["PaymentAgentResult", "SalespersonA2AClient", "PAYMENT_AGENT_BASE_URL"]

--- a/src/my_agent/salesperson_agent/salesperson_a2a/payment_tasks.py
+++ b/src/my_agent/salesperson_agent/salesperson_a2a/payment_tasks.py
@@ -176,7 +176,7 @@ async def prepare_query_status_payload(
     correlation_id: str,
 ) -> Dict[str, Any]:
     """Build the task and payload needed for the payment status skill."""
-    from my_a2a_common import build_query_status_message
+    from my_a2a_common.a2a_salesperson_payment.messages import build_query_status_message
 
     status_request = QueryStatusRequest(correlation_id=correlation_id)
     message = build_query_status_message(status_request)
@@ -222,7 +222,7 @@ async def prepare_create_order_payload_with_client(
     the task wholesale to the A2A client or extract the JSON body to call the
     remote skill directly.
     """
-    from my_a2a_common import build_create_order_message
+    from my_a2a_common.a2a_salesperson_payment.messages import build_create_order_message
 
     channel_enum = PaymentChannel(channel)
     resolved_items = await _resolve_items_via_product_tool(items, client=client)

--- a/src/tests/test_base_a2a_client.py
+++ b/src/tests/test_base_a2a_client.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from a2a.types import Message, Role, Task, TaskState, TaskStatus
+
+from my_agent.base_a2a_client import BaseA2AClient
+from utils.status import Status
+
+
+def _build_task() -> Task:
+    message = Message(message_id="msg-1", role=Role.user, context_id="ctx-1", parts=[])
+    return Task(
+        id="task-1",
+        context_id="ctx-1",
+        history=[message],
+        status=TaskStatus(state=TaskState.submitted),
+        metadata={"skill_id": "test.skill", "correlation_id": "ctx-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_a2a_client_send_task_success() -> None:
+    task = _build_task()
+    response_message = Message(message_id="resp-1", role=Role.agent, context_id="ctx-1", parts=[])
+
+    captured_request: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_request["url"] = str(request.url)
+        body = json.loads(request.content.decode())
+        captured_request["body"] = body
+        assert body["method"] == "message.send"
+        metadata = body["params"]["metadata"]
+        assert metadata["task"]["metadata"]["skill_id"] == "test.skill"
+        assert metadata["task"]["history"][0]["messageId"] == "msg-1"
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": {
+                    "status": Status.SUCCESS.value,
+                    "message": "SUCCESS",
+                    "data": response_message.model_dump(mode="json"),
+                },
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://payment.example") as http_client:
+        async with BaseA2AClient(base_url="https://payment.example", client=http_client) as client:
+            message = await client.send_task(task)
+
+    assert captured_request["url"].endswith("/")
+    assert message.message_id == "resp-1"
+    assert message.role is Role.agent
+
+
+@pytest.mark.asyncio
+async def test_base_a2a_client_raises_on_error_status() -> None:
+    task = _build_task()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": {
+                    "status": Status.FAILURE.value,
+                    "message": "gateway failure",
+                    "data": {},
+                },
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://payment.example") as http_client:
+        async with BaseA2AClient(base_url="https://payment.example", client=http_client) as client:
+            with pytest.raises(RuntimeError, match="status '01'"):
+                await client.send_task(task)

--- a/src/tests/test_payment_a2a_app.py
+++ b/src/tests/test_payment_a2a_app.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from a2a.types import MessageSendParams, Task, TaskState, TaskStatus
+
+from my_a2a_common import build_create_order_message, build_payment_response_message
+from my_a2a_common.payment_schemas import CustomerInfo, PaymentItem, PaymentMethod, PaymentRequest, PaymentResponse
+from my_a2a_common.payment_schemas.payment_enums import PaymentChannel, PaymentStatus
+from importlib import import_module
+
+a2a_app_module = import_module("my_agent.payment_agent.payment_a2a.a2a_app")
+from utils.status import Status
+
+
+def _order_task() -> Task:
+    request = PaymentRequest(
+        correlation_id="corr-abc",
+        items=[
+            PaymentItem(
+                sku="sku-10",
+                name="Adapter",
+                quantity=2,
+                unit_price=15.0,
+                currency="USD",
+            )
+        ],
+        customer=CustomerInfo(name="Bob", email="bob@example.com"),
+        method=PaymentMethod(
+            channel=PaymentChannel.REDIRECT,
+            return_url="https://return",
+            cancel_url="https://cancel",
+        ),
+    )
+    message = build_create_order_message(request)
+    return Task(
+        id="task-abc",
+        context_id=request.correlation_id,
+        history=[message],
+        status=TaskStatus(state=TaskState.submitted),
+        metadata={
+            "skill_id": "payment.create-order",
+            "correlation_id": request.correlation_id,
+        },
+    )
+
+
+class _DummyHandler:
+    def __init__(self, response_message):
+        self._response_message = response_message
+        self.calls = 0
+        self.last_task: Task | None = None
+
+    def handle_task(self, task: Task):
+        self.calls += 1
+        self.last_task = task
+        return self._response_message
+
+
+@pytest.mark.asyncio
+async def test_payment_a2a_app_message_send(monkeypatch) -> None:
+    task = _order_task()
+    payload = {"task": task.model_dump(mode="json")}
+    params = MessageSendParams(
+        message=task.history[-1],
+        metadata=payload,
+    )
+
+    payment_response = PaymentResponse(
+        correlation_id="corr-abc",
+        status=PaymentStatus.SUCCESS,
+        order_id="order-abc",
+    )
+    response_message = build_payment_response_message(payment_response)
+
+    dummy_handler = _DummyHandler(response_message)
+    monkeypatch.setattr(a2a_app_module, "_PAYMENT_HANDLER", dummy_handler)
+
+    transport = httpx.ASGITransport(app=a2a_app_module.a2a_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/",
+            json={
+                "jsonrpc": "2.0",
+                "id": "req-1",
+                "method": "message.send",
+                "params": params.model_dump(mode="json"),
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["status"] == Status.SUCCESS.value
+    assert body["result"]["data"]["contextId"] == "corr-abc"
+    assert dummy_handler.calls == 1
+    assert dummy_handler.last_task is not None
+    assert dummy_handler.last_task.metadata["skill_id"] == "payment.create-order"
+
+
+@pytest.mark.asyncio
+async def test_payment_a2a_app_missing_task_metadata() -> None:
+    params = MessageSendParams(message=_order_task().history[-1], metadata={})
+
+    transport = httpx.ASGITransport(app=a2a_app_module.a2a_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/",
+            json={
+                "jsonrpc": "2.0",
+                "id": "req-err",
+                "method": "message.send",
+                "params": params.model_dump(mode="json"),
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == -32602
+    assert "task" in body["error"]["message"]

--- a/src/tests/test_salesperson_a2a_client.py
+++ b/src/tests/test_salesperson_a2a_client.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from a2a.types import Task, TaskState, TaskStatus
+
+from my_a2a_common import build_create_order_message, build_payment_response_message
+from my_a2a_common.payment_schemas import CustomerInfo, PaymentItem, PaymentMethod, PaymentRequest, PaymentResponse
+from my_a2a_common.payment_schemas.payment_enums import PaymentChannel, PaymentStatus
+from my_agent.salesperson_agent.salesperson_a2a.client import PaymentAgentResult, SalespersonA2AClient
+
+
+def _build_order_task() -> Task:
+    payment_request = PaymentRequest(
+        correlation_id="corr-123",
+        items=[
+            PaymentItem(
+                sku="sku-1",
+                name="Widget",
+                quantity=1,
+                unit_price=25.0,
+                currency="USD",
+            )
+        ],
+        customer=CustomerInfo(name="Alice", email="alice@example.com"),
+        method=PaymentMethod(
+            channel=PaymentChannel.REDIRECT,
+            return_url="https://return",
+            cancel_url="https://cancel",
+        ),
+    )
+
+    message = build_create_order_message(payment_request)
+    return Task(
+        id="task-123",
+        context_id=payment_request.correlation_id,
+        history=[message],
+        status=TaskStatus(state=TaskState.submitted),
+        metadata={
+            "skill_id": "payment.create-order",
+            "correlation_id": payment_request.correlation_id,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_salesperson_a2a_client_parses_payment_response() -> None:
+    task = _build_order_task()
+    payload = {"task": task.model_dump(mode="json")}
+
+    response = PaymentResponse(
+        correlation_id="corr-123",
+        status=PaymentStatus.SUCCESS,
+        order_id="order-999",
+    )
+    response_message = build_payment_response_message(response)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        assert body["params"]["metadata"]["task"]["contextId"] == "corr-123"
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": {
+                    "status": "00",
+                    "message": "SUCCESS",
+                    "data": response_message.model_dump(mode="json"),
+                },
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://payment.example") as http_client:
+        async with SalespersonA2AClient(base_url="https://payment.example", client=http_client) as client:
+            result = await client.create_order(payload)
+
+    assert isinstance(result, PaymentAgentResult)
+    assert result.response.correlation_id == "corr-123"
+    assert result.response.order_id == "order-999"
+    assert result.response.status is PaymentStatus.SUCCESS


### PR DESCRIPTION
## Summary
- add a shared BaseA2AClient plus a SalespersonA2AClient wrapper for sending payment tasks over JSON-RPC
- replace the payment agent server with an explicit Starlette JSON-RPC endpoint that delegates to PaymentAgentHandler
- extend the test suite for the new clients and server flow and add the email-validator dependency required by payment schemas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d7456d6648832c83ecbe8f54a1d3c5