### PR TITLE
Integrate salesperson A2A client tools

### DIFF
--- a/src/my_agent/salesperson_agent/agent.py
+++ b/src/my_agent/salesperson_agent/agent.py
@@ -1,10 +1,12 @@
+from typing import Any, Mapping, Sequence
+
 from google.adk.agents import Agent, LlmAgent
 from google.adk.models.lite_llm import LiteLlm
+from google.adk.tools import FunctionTool
 
 from config import *
+from my_agent.salesperson_agent.salesperson_a2a import SalespersonA2AClient
 from my_agent.salesperson_agent.salesperson_a2a.remote_agent import get_remote_payment_agent
-from my_agent.salesperson_agent.salesperson_a2a.payment_tasks import prepare_create_order_payload_tool, \
-    prepare_query_status_payload_tool
 from my_agent.salesperson_agent.salesperson_mcp_client import prepare_find_product_tool, prepare_calc_shipping_tool, \
     prepare_reserve_stock_tool
 
@@ -12,6 +14,35 @@ instruction_path = os.path.join(os.path.dirname(__file__), "instruction.txt")
 with open(instruction_path, "r", encoding="utf-8") as f:
     _INSTRUCTION = f.read().strip()
 _DESCRIPTION = "Salesperson who helps Customers to find products, calculate shipping costs and reserve stock."
+
+
+async def _create_payment_order(
+    items: Sequence[Any],
+    customer: Any,
+    channel: str,
+    *,
+    note: str | None = None,
+    metadata: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    async with SalespersonA2AClient() as client:
+        response = await client.create_order(
+            items=items,
+            customer=customer,
+            channel=channel,
+            note=note,
+            metadata=dict(metadata) if metadata is not None else None,
+        )
+    return response.to_dict()
+
+
+async def _query_payment_order_status(correlation_id: str) -> dict[str, Any]:
+    async with SalespersonA2AClient() as client:
+        response = await client.query_status(correlation_id)
+    return response.to_dict()
+
+
+create_payment_order_tool = FunctionTool(_create_payment_order)
+query_payment_order_status_tool = FunctionTool(_query_payment_order_status)
 
 
 def gemini_salesperson_agent() -> Agent:
@@ -25,8 +56,8 @@ def gemini_salesperson_agent() -> Agent:
             prepare_find_product_tool,
             prepare_calc_shipping_tool,
             prepare_reserve_stock_tool,
-            prepare_create_order_payload_tool,
-            prepare_query_status_payload_tool,
+            create_payment_order_tool,
+            query_payment_order_status_tool,
         ],
     )
 
@@ -46,8 +77,8 @@ def llm_salesperson_agent() -> LlmAgent:
             prepare_find_product_tool,
             prepare_calc_shipping_tool,
             prepare_reserve_stock_tool,
-            prepare_create_order_payload_tool,
-            prepare_query_status_payload_tool,
+            create_payment_order_tool,
+            query_payment_order_status_tool,
         ],
     )
 

--- a/src/my_agent/salesperson_agent/salesperson_a2a/__init__.py
+++ b/src/my_agent/salesperson_agent/salesperson_a2a/__init__.py
@@ -1,22 +1,17 @@
 """Public helpers for the salesperson ↔ payment A2A integration."""
 
-from .salesperson_a2a_client import PaymentAgentResult, SalespersonA2AClient
+from .salesperson_a2a_client import SalespersonA2AClient
 from .payment_tasks import (
     prepare_create_order_payload,
-    prepare_create_order_payload_tool,
     prepare_create_order_payload_with_client,
     prepare_query_status_payload,
-    prepare_query_status_payload_tool,
 )
 from .remote_agent import get_remote_payment_agent
 
 __all__ = [
-    "PaymentAgentResult",
     "SalespersonA2AClient",
     "prepare_create_order_payload",
-    "prepare_create_order_payload_tool",
     "prepare_create_order_payload_with_client",
     "prepare_query_status_payload",
-    "prepare_query_status_payload_tool",
     "get_remote_payment_agent",
 ]

--- a/src/my_agent/salesperson_agent/salesperson_a2a/payment_tasks.py
+++ b/src/my_agent/salesperson_agent/salesperson_a2a/payment_tasks.py
@@ -21,8 +21,6 @@ from typing import Any, Dict, Optional, Sequence, Tuple, List, Literal
 from uuid import uuid4
 
 from a2a.types import Task, TaskStatus, TaskState
-from google.adk.tools import FunctionTool
-
 from my_a2a_common.payment_schemas import *
 from my_a2a_common.payment_schemas.payment_enums import PaymentChannel
 from my_a2a_common.a2a_salesperson_payment.content import build_artifact, extract_payment_request, \
@@ -246,14 +244,8 @@ async def prepare_create_order_payload_with_client(
     }
 
 
-prepare_create_order_payload_tool = FunctionTool(prepare_create_order_payload)
-prepare_query_status_payload_tool = FunctionTool(prepare_query_status_payload)
-
-
 __all__ = [
     "prepare_create_order_payload",
     "prepare_query_status_payload",
-    "prepare_create_order_payload_tool",
-    "prepare_query_status_payload_tool",
     "prepare_create_order_payload_with_client",
 ]

--- a/src/tests/test_salesperson_a2a_client.py
+++ b/src/tests/test_salesperson_a2a_client.py
@@ -8,9 +8,16 @@ import pytest
 from a2a.types import Task, TaskState, TaskStatus
 
 from my_a2a_common import build_create_order_message, build_payment_response_message
-from my_a2a_common.payment_schemas import CustomerInfo, PaymentItem, PaymentMethod, PaymentRequest, PaymentResponse
+from my_a2a_common.payment_schemas import (
+    CustomerInfo,
+    PaymentItem,
+    PaymentMethod,
+    PaymentRequest,
+    PaymentResponse,
+)
 from my_a2a_common.payment_schemas.payment_enums import PaymentChannel, PaymentStatus
-from my_agent.salesperson_agent.salesperson_a2a.salesperson_a2a_client import PaymentAgentResult, SalespersonA2AClient
+from my_agent.salesperson_agent.salesperson_a2a import salesperson_a2a_client
+from my_agent.salesperson_agent.salesperson_a2a.salesperson_a2a_client import SalespersonA2AClient
 
 
 def _build_order_task() -> Task:
@@ -47,9 +54,17 @@ def _build_order_task() -> Task:
 
 
 @pytest.mark.asyncio
-async def test_salesperson_a2a_client_parses_payment_response() -> None:
+async def test_salesperson_a2a_client_parses_payment_response(monkeypatch: pytest.MonkeyPatch) -> None:
     task = _build_order_task()
-    payload = {"task": task.model_dump(mode="json")}
+
+    async def fake_prepare_create_order_payload(*args, **kwargs):
+        return {"task": task.model_dump(mode="json")}
+
+    monkeypatch.setattr(
+        salesperson_a2a_client,
+        "prepare_create_order_payload",
+        fake_prepare_create_order_payload,
+    )
 
     response = PaymentResponse(
         correlation_id="corr-123",
@@ -77,9 +92,57 @@ async def test_salesperson_a2a_client_parses_payment_response() -> None:
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="https://payment.example") as http_client:
         async with SalespersonA2AClient(base_url="https://payment.example", client=http_client) as client:
-            result = await client.create_order(payload)
+            result = await client.create_order(
+                items=[{"sku": "sku-1", "quantity": 1}],
+                customer={"name": "Alice", "email": "alice@example.com"},
+                channel="redirect",
+            )
 
-    assert isinstance(result, PaymentAgentResult)
-    assert result.response.correlation_id == "corr-123"
-    assert result.response.order_id == "order-999"
-    assert result.response.status is PaymentStatus.SUCCESS
+    assert result.data["response"]["correlation_id"] == "corr-123"
+    assert result.data["response"]["order_id"] == "order-999"
+    assert result.data["response"]["status"] == PaymentStatus.SUCCESS.value
+
+
+@pytest.mark.asyncio
+async def test_salesperson_a2a_client_queries_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    task = _build_order_task()
+
+    async def fake_prepare_query_status_payload(correlation_id: str):
+        assert correlation_id == "corr-123"
+        return {"task": task.model_dump(mode="json")}
+
+    monkeypatch.setattr(
+        salesperson_a2a_client,
+        "prepare_query_status_payload",
+        fake_prepare_query_status_payload,
+    )
+
+    response = PaymentResponse(
+        correlation_id="corr-123",
+        status=PaymentStatus.PENDING,
+        order_id="order-999",
+    )
+    response_message = build_payment_response_message(response)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        assert body["params"]["metadata"]["task"]["contextId"] == "corr-123"
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": {
+                    "status": "00",
+                    "message": "SUCCESS",
+                    "data": response_message.model_dump(mode="json"),
+                },
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://payment.example") as http_client:
+        async with SalespersonA2AClient(base_url="https://payment.example", client=http_client) as client:
+            result = await client.query_status("corr-123")
+
+    assert result.data["response"]["status"] == PaymentStatus.PENDING.value


### PR DESCRIPTION
## Summary
- integrate `SalespersonA2AClient` into the salesperson root agent with new create/query payment tools
- update the A2A client to build payloads internally and return `ResponseFormatA2A` data
- refresh tests to exercise the revised client interface

## Testing
- pytest *(fails: ImportError: cannot import name 'a2a_app' from 'my_agent.payment_agent.payment_a2a.a2a_app')*


------
https://chatgpt.com/codex/tasks/task_e_68d7b0b56fe4832c94823b36d0967069