### PR TITLE
Add Docker builds and Kubernetes manifests for microservices deployment

### DIFF
--- a/deploy/docker/Dockerfile.a2a_app
+++ b/deploy/docker/Dockerfile.a2a_app
@@ -1,0 +1,30 @@
+# Sử dụng Python 3.11-slim vì dự án yêu cầu Python >=3.10 và biến thể slim giúp giảm kích thước image.
+FROM python:3.11-slim
+# Vô hiệu hoá việc tạo file .pyc để image gọn hơn và tránh ghi đĩa không cần thiết.
+ENV PYTHONDONTWRITEBYTECODE=1
+# Bật unbuffered output để log hiển thị ngay lập tức trong container.
+ENV PYTHONUNBUFFERED=1
+# Đặt thư mục làm việc về /app để tất cả thao tác tiếp theo có cùng ngữ cảnh.
+WORKDIR /app
+# Sao chép file requirements trước để tối ưu cache layer của Docker khi dependency không đổi.
+COPY requirements.txt pyproject.toml ./
+# Cài đặt build dependencies tối thiểu (curl và build-essential) để pip có thể build wheel nếu cần, sau đó xoá cache apt để giảm kích thước image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+# Cài đặt phụ thuộc Python cho service dựa trên requirements.txt.
+RUN pip install --no-cache-dir -r requirements.txt
+# Sao chép toàn bộ mã nguồn để container có thể truy cập các module nội bộ.
+COPY src ./src
+# Thiết lập biến môi trường để service lắng nghe trên mọi interface và cổng mặc định 8081.
+ENV PAYMENT_AGENT_SERVER_HOST=0.0.0.0
+ENV PAYMENT_AGENT_SERVER_PORT=8081
+# Mặc định cấu hình URL của các MCP server để a2a app giao tiếp trong cụm Kubernetes.
+ENV MCP_SERVER_HOST_PAYMENT=payment-tool
+ENV MCP_SERVER_PORT_PAYMENT=8000
+ENV MCP_SERVER_HOST_SALESPERSON=salesperson-tool
+ENV MCP_SERVER_PORT_SALESPERSON=8001
+# Mở cổng 8081 vì đây là nơi service a2a_app phục vụ HTTP.
+EXPOSE 8081
+# Chạy uvicorn với module a2a_app để khởi động Starlette app khi container start.
+CMD ["uvicorn", "my_agent.payment_agent.payment_a2a.a2a_app:a2a_app", "--host", "0.0.0.0", "--port", "8081"]

--- a/deploy/docker/Dockerfile.adk_web
+++ b/deploy/docker/Dockerfile.adk_web
@@ -1,0 +1,32 @@
+# Dùng Python 3.11-slim để chạy CLI google-adk nhẹ và đồng nhất với các service khác.
+FROM python:3.11-slim
+# Ngăn tạo file .pyc để tối ưu kích thước image.
+ENV PYTHONDONTWRITEBYTECODE=1
+# Bật chế độ unbuffered giúp log real-time phục vụ quan sát trên Kubernetes.
+ENV PYTHONUNBUFFERED=1
+# Thiết lập thư mục làm việc chính của ứng dụng web.
+WORKDIR /app
+# Sao chép file requirements và pyproject trước để tối ưu cache khi cài dependency.
+COPY requirements.txt pyproject.toml ./
+# Cài build-essential để hỗ trợ biên dịch gói cần thiết rồi dọn sạch cache apt.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+# Cài đặt toàn bộ dependency Python bao gồm google-adk để có CLI adk web.
+RUN pip install --no-cache-dir -r requirements.txt
+# Chép mã nguồn để adk web có thể load agent definition trong thư mục src/my_agent.
+COPY src ./src
+# Thiết lập port mặc định 8080 cho giao diện web và cho phép override qua biến môi trường.
+ENV ADK_WEB_HOST=0.0.0.0
+ENV ADK_WEB_PORT=8080
+# Đặt mặc định thông tin kết nối tới các service nội bộ theo tên service trong Kubernetes.
+ENV MCP_SERVER_HOST_PAYMENT=payment-tool
+ENV MCP_SERVER_PORT_PAYMENT=8000
+ENV MCP_SERVER_HOST_SALESPERSON=salesperson-tool
+ENV MCP_SERVER_PORT_SALESPERSON=8001
+ENV PAYMENT_AGENT_SERVER_HOST=a2a-app
+ENV PAYMENT_AGENT_SERVER_PORT=8081
+# Mở cổng 8080 để ingress có thể truy cập ứng dụng web.
+EXPOSE 8080
+# Khởi chạy giao diện ADK web trỏ vào thư mục định nghĩa agent.
+CMD ["adk", "web", "/app/src/my_agent", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy/docker/Dockerfile.server_payment_tool
+++ b/deploy/docker/Dockerfile.server_payment_tool
@@ -1,0 +1,25 @@
+# Sử dụng Python 3.11-slim để nhất quán môi trường runtime giữa các service Python.
+FROM python:3.11-slim
+# Ngăn Python sinh file .pyc để giữ image gọn.
+ENV PYTHONDONTWRITEBYTECODE=1
+# Bật unbuffered output giúp log xuất ngay, thuận tiện khi chạy trong container/k8s.
+ENV PYTHONUNBUFFERED=1
+# Thiết lập thư mục làm việc chung cho ứng dụng.
+WORKDIR /app
+# Sao chép file dependency trước nhằm tận dụng cache khi mã nguồn thay đổi.
+COPY requirements.txt pyproject.toml ./
+# Cài đặt gói build-essential phục vụ việc build wheel và xoá cache apt để giảm dung lượng.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+# Cài đặt toàn bộ thư viện Python được yêu cầu cho MCP server.
+RUN pip install --no-cache-dir -r requirements.txt
+# Sao chép mã nguồn dự án vào container để uvicorn có thể import module.
+COPY src ./src
+# Đặt biến môi trường để server lắng nghe trên tất cả interface và cổng mặc định 8000.
+ENV MCP_SERVER_HOST_PAYMENT=0.0.0.0
+ENV MCP_SERVER_PORT_PAYMENT=8000
+# Mở cổng 8000 nhằm khai báo cho runtime biết MCP server sẽ phục vụ tại đây.
+EXPOSE 8000
+# Khởi động uvicorn với ứng dụng FastAPI của server_payment_tool khi container chạy.
+CMD ["uvicorn", "my_mcp.payment.server_payment_tool:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/docker/Dockerfile.server_salesperson_tool
+++ b/deploy/docker/Dockerfile.server_salesperson_tool
@@ -1,0 +1,25 @@
+# Dùng Python 3.11-slim để tương thích với yêu cầu dự án và giảm dung lượng image.
+FROM python:3.11-slim
+# Tắt việc sinh file .pyc để tối ưu dung lượng và I/O.
+ENV PYTHONDONTWRITEBYTECODE=1
+# Đảm bảo log được flush ngay lập tức cho môi trường container.
+ENV PYTHONUNBUFFERED=1
+# Chọn /app làm thư mục làm việc thống nhất cho thao tác copy và chạy lệnh.
+WORKDIR /app
+# Sao chép file định nghĩa dependency trước để tận dụng cache layer.
+COPY requirements.txt pyproject.toml ./
+# Cài đặt công cụ build cần thiết rồi dọn dẹp cache apt nhằm giữ image nhỏ gọn.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+# Cài các gói Python phục vụ MCP salesperson server.
+RUN pip install --no-cache-dir -r requirements.txt
+# Copy toàn bộ mã nguồn để uvicorn load được module salesperson.
+COPY src ./src
+# Đặt biến môi trường để service nghe ở cổng 8001 và trên mọi interface.
+ENV MCP_SERVER_HOST_SALESPERSON=0.0.0.0
+ENV MCP_SERVER_PORT_SALESPERSON=8001
+# Mở cổng 8001 tương ứng với port dịch vụ MCP salesperson.
+EXPOSE 8001
+# Khởi động uvicorn chạy ứng dụng FastAPI của server_salesperson_tool.
+CMD ["uvicorn", "my_mcp.salesperson.server_salesperson_tool:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -1,0 +1,296 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agent-ecosystem
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: a2a-app
+  namespace: agent-ecosystem
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: a2a-app
+  template:
+    metadata:
+      labels:
+        app: a2a-app
+    spec:
+      containers:
+        - name: a2a-app
+          image: your-registry/a2a-app:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8081
+          env:
+            - name: PAYMENT_AGENT_SERVER_HOST
+              value: "0.0.0.0"
+            - name: PAYMENT_AGENT_SERVER_PORT
+              value: "8081"
+            - name: MCP_SERVER_HOST_PAYMENT
+              value: payment-tool
+            - name: MCP_SERVER_PORT_PAYMENT
+              value: "8000"
+            - name: MCP_SERVER_HOST_SALESPERSON
+              value: salesperson-tool
+            - name: MCP_SERVER_PORT_SALESPERSON
+              value: "8001"
+            - name: MCP_PAYMENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: mcp-payment-token
+            - name: MCP_SALESPERSON_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: mcp-salesperson-token
+          readinessProbe:
+            httpGet:
+              path: /.well-known/agent-card.json
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /.well-known/agent-card.json
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: a2a-app
+  namespace: agent-ecosystem
+spec:
+  type: ClusterIP
+  selector:
+    app: a2a-app
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-tool
+  namespace: agent-ecosystem
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payment-tool
+  template:
+    metadata:
+      labels:
+        app: payment-tool
+    spec:
+      containers:
+        - name: payment-tool
+          image: your-registry/payment-tool:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: MCP_SERVER_HOST_PAYMENT
+              value: "0.0.0.0"
+            - name: MCP_SERVER_PORT_PAYMENT
+              value: "8000"
+            - name: MCP_PAYMENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: mcp-payment-token
+          readinessProbe:
+            httpGet:
+              path: /mcp
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /mcp
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-tool
+  namespace: agent-ecosystem
+spec:
+  type: ClusterIP
+  selector:
+    app: payment-tool
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: salesperson-tool
+  namespace: agent-ecosystem
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: salesperson-tool
+  template:
+    metadata:
+      labels:
+        app: salesperson-tool
+    spec:
+      containers:
+        - name: salesperson-tool
+          image: your-registry/salesperson-tool:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8001
+          env:
+            - name: MCP_SERVER_HOST_SALESPERSON
+              value: "0.0.0.0"
+            - name: MCP_SERVER_PORT_SALESPERSON
+              value: "8001"
+            - name: MCP_SALESPERSON_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: mcp-salesperson-token
+          readinessProbe:
+            httpGet:
+              path: /mcp
+              port: 8001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /mcp
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: salesperson-tool
+  namespace: agent-ecosystem
+spec:
+  type: ClusterIP
+  selector:
+    app: salesperson-tool
+  ports:
+    - name: http
+      port: 8001
+      targetPort: 8001
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adk-web
+  namespace: agent-ecosystem
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: adk-web
+  template:
+    metadata:
+      labels:
+        app: adk-web
+    spec:
+      containers:
+        - name: adk-web
+          image: your-registry/adk-web:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ADK_WEB_HOST
+              value: "0.0.0.0"
+            - name: ADK_WEB_PORT
+              value: "8080"
+            - name: PAYMENT_AGENT_SERVER_HOST
+              value: a2a-app
+            - name: PAYMENT_AGENT_SERVER_PORT
+              value: "8081"
+            - name: MCP_SERVER_HOST_PAYMENT
+              value: payment-tool
+            - name: MCP_SERVER_PORT_PAYMENT
+              value: "8000"
+            - name: MCP_SERVER_HOST_SALESPERSON
+              value: salesperson-tool
+            - name: MCP_SERVER_PORT_SALESPERSON
+              value: "8001"
+            - name: MCP_PAYMENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: mcp-payment-token
+            - name: MCP_SALESPERSON_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: mcp-salesperson-token
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: adk-web
+  namespace: agent-ecosystem
+spec:
+  type: ClusterIP
+  selector:
+    app: adk-web
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-secrets
+  namespace: agent-ecosystem
+stringData:
+  mcp-payment-token: "replace-with-real-payment-token"
+  mcp-salesperson-token: "replace-with-real-salesperson-token"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: adk-web
+  namespace: agent-ecosystem
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: adk.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: adk-web
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary
- add Dockerfiles for the a2a app, payment MCP server, salesperson MCP server, and ADK web UI with line-by-line comments explaining each instruction
- create a consolidated Kubernetes manifest defining deployments, services, secrets, and ingress to run the four services together

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de415ab3a8832cb61b4c970f729e6f